### PR TITLE
Update composer autoload path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "suggest": {
     },
     "autoload": {
-        "psr-0": { "OTPHP": "lib/" }
+        "psr-0": { "OTPHP": "Spomky/OTPHP/lib/" }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
When trying to autoload the spomky-labs/otphp library through composer, I was getting an error about not being able to find the class.

I checked in the `lib/vendor/composer/autoload_namespaces.php` file and noticed that composer was looking for the library in `$vendorDir/spomky-labs/otphp/lib` when it really should be looking in `$vendorDir/spomky-labs/otphp/Spomky/OTPHP/lib`. 

I forked the repo, changed the composer.json file, and tested it in my project. Once I made the update, it autoloaded correctly.
