### PR TITLE
Made hasSemicolon public to bring it inline with the docs

### DIFF
--- a/lib/OTPHP/OTP.php
+++ b/lib/OTPHP/OTP.php
@@ -70,7 +70,7 @@ abstract class OTP implements OTPInterface
      *
      * @return boolean
      */
-    private function hasSemicolon($value)
+    public function hasSemicolon($value)
     {
         $semicolons = array(':', '%3A', '%3a');
         foreach ($semicolons as $semicolon) {


### PR DESCRIPTION
The documentation linked below has an example implementation which uses hasSemicolon. The hasSemicolon() method is marked as private in OTP.php. I've changed it to public.

https://github.com/Spomky-Labs/otphp/blob/3.0.x/doc/Extend.md
