### PR TITLE
Fix to work with any digest size

### DIFF
--- a/lib/OTP.php
+++ b/lib/OTP.php
@@ -18,7 +18,7 @@ abstract class OTP implements OTPInterface
         foreach (str_split($hash, 2) as $hex) {
             $hmac[] = hexdec($hex);
         }
-        $offset = $hmac[19] & 0xf;
+        $offset = $hmac[count($hmac) - 1] & 0xf;
         $code = ($hmac[$offset + 0] & 0x7F) << 24 |
             ($hmac[$offset + 1] & 0xFF) << 16 |
             ($hmac[$offset + 2] & 0xFF) << 8 |


### PR DESCRIPTION
Offset should be calculated using the last byte of the digest.  Hardcoding for byte 19 only works for 160-bit digests (e.g. sha1). See, e.g., line 163 of [FreeOTP Token.java](https://fedorahosted.org/freeotp/browser/android/app/src/main/java/org/fedorahosted/freeotp/Token.java?rev=e1dbb3c6c3faf112a4bebb75057e0f739c52ac97).