### PR TITLE
Don't include issuer in URI path when it is included as a parameter

### DIFF
--- a/src/OTP.php
+++ b/src/OTP.php
@@ -114,7 +114,7 @@ abstract class OTP implements OTPInterface
         return sprintf(
             'otpauth://%s/%s?%s',
             $type,
-            rawurlencode((null !== $this->getIssuer() ? $this->getIssuer().':' : '').$this->getLabel()),
+            rawurlencode((null !== $this->getIssuer() && !$this->isIssuerIncludedAsParameter() ? $this->getIssuer().':' : '').$this->getLabel()),
             $params
         );
     }


### PR DESCRIPTION
I noticed when testing with QR codes that Google Authenticator doesn't recognize the issuer when the `otpauth://totp/Issuer:Label?secret=1234` scheme is used and it instead needs to be `otpauth://totp/Label?secret=1234&issuer=Issuer`.

This minor change makes it so if the `isIssuerIncludedAsParameter()` property is true, the path component won't get the issuer, and instead it will be a query parameter as is already the case.

Feel free to merge if this change makes sense overall.