### PR TITLE
The label should not be mandatory

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -20,7 +20,7 @@ final class Factory
      *
      * @throws \InvalidArgumentException
      *
-     * @return \OTPHP\TOTP|\OTPHP\HOTP
+     * @return \OTPHP\TOTPInterface|\OTPHP\HOTPInterface
      */
     public static function loadFromProvisioningUri($uri)
     {

--- a/src/HOTP.php
+++ b/src/HOTP.php
@@ -18,13 +18,13 @@ final class HOTP extends OTP implements HOTPInterface
     /**
      * HOTP constructor.
      *
-     * @param string      $label
+     * @param string|null $label
      * @param string|null $secret
      * @param int         $counter
      * @param string      $digest
      * @param int         $digits
      */
-    public function __construct($label, $secret = null, $counter = 0, $digest = 'sha1', $digits = 6)
+    public function __construct($label = null, $secret = null, $counter = 0, $digest = 'sha1', $digits = 6)
     {
         parent::__construct($label, $secret, $digest, $digits);
         $this->setCounter($counter);

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -93,7 +93,7 @@ abstract class OTP implements OTPInterface
      */
     protected function generateURI($type, array $options)
     {
-        $label =$this->getLabel();
+        $label = $this->getLabel();
         Assertion::string($label, 'The label is not set.');
         Assertion::false($this->hasColon($label), 'Label must not contain a colon.');
         $options = array_merge($options, $this->getParameters());

--- a/src/ParameterTrait.php
+++ b/src/ParameterTrait.php
@@ -80,12 +80,11 @@ trait ParameterTrait
     }
 
     /**
-     * @param string $label
+     * @param string|null $label
      */
     private function setLabel($label)
     {
-        Assertion::string($label, 'Label must be a string.');
-        Assertion::false($this->hasColon($label), 'Label must not contain a colon.');
+        Assertion::nullOrString($label, 'Label must be null or a string.');
 
         $this->label = $label;
     }
@@ -165,6 +164,8 @@ trait ParameterTrait
 
     /**
      * @param string $parameter
+     *
+     * @return bool
      */
     public function hasParameter($parameter)
     {

--- a/src/TOTP.php
+++ b/src/TOTP.php
@@ -18,13 +18,13 @@ final class TOTP extends OTP implements TOTPInterface
     /**
      * TOTP constructor.
      *
-     * @param string      $label
+     * @param string|null $label
      * @param string|null $secret
      * @param int         $period
      * @param string      $digest
      * @param int         $digits
      */
-    public function __construct($label, $secret = null, $period = 30, $digest = 'sha1', $digits = 6)
+    public function __construct($label = null, $secret = null, $period = 30, $digest = 'sha1', $digits = 6)
     {
         parent::__construct($label, $secret, $digest, $digits);
         $this->setPeriod($period);

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -15,11 +15,22 @@ class HOTPTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Label must be a string.
+     * @expectedExceptionMessage Label must be null or a string.
+     */
+    public function testLabelNotNullAndNotAStringDefined()
+    {
+        new HOTP(1234, 'JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The label is not set.
      */
     public function testLabelNotDefined()
     {
-        new HOTP(null, 'JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $hotp = new HOTP();
+        $this->assertTrue(is_string($hotp->at(0)));
+        $hotp->getProvisioningUri();
     }
 
     /**
@@ -48,7 +59,8 @@ class HOTPTest extends \PHPUnit_Framework_TestCase
      */
     public function testLabelHasColon()
     {
-        new HOTP('foo%3Abar', 'JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $hotp = new HOTP('foo%3Abar', 'JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $hotp->getProvisioningUri();
     }
 
     /**
@@ -57,7 +69,8 @@ class HOTPTest extends \PHPUnit_Framework_TestCase
      */
     public function testLabelHasColon2()
     {
-        new HOTP('foo:bar', 'JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $hotp = new HOTP('foo:bar', 'JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $hotp->getProvisioningUri();
     }
 
     /**

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -14,6 +14,17 @@ use OTPHP\TOTP;
 
 class TOTPTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The label is not set.
+     */
+    public function testLabelNotDefined()
+    {
+        $hotp = new TOTP();
+        $this->assertTrue(is_string($hotp->now()));
+        $hotp->getProvisioningUri();
+    }
+
     public function testCustomParameter()
     {
         $otp = new TOTP('alice@foo.bar', 'JDDK4U6G3BJLEZ7Y', 20, 'sha512', 8);


### PR DESCRIPTION
This PR fixes #60 by allowing the label to be null.
Assertions are now made during the provisioning URI computation.