### PR TITLE
Fixed verify error

### DIFF
--- a/doc/Customize.md
+++ b/doc/Customize.md
@@ -20,7 +20,7 @@ By default, a 512 bits secret is generated. If you need, you can use your own se
 use OTPHP\TOTP;
 use ParagonIE\ConstantTime\Base32;
 
-$mySecret = trim(Base32::encode(random_bytes(128)), '='); // We generate our own 1024 bits secret
+$mySecret = trim(Base32::encodeUpper(random_bytes(128)), '='); // We generate our own 1024 bits secret
 $otp = TOTP::create($mySecret);
 ```
 


### PR DESCRIPTION
Base32::doDecode() only expects characters in the correct base32 alphabet

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Tests added   |  <!--highly recommended for new features-->
| Doc PR        |  <!--highly recommended for new features-->

I followed the documentation and did:

* Created URI and saved it in db
* On user login I load the URI from db, transform it to OTP object and verify the code sent by the user

But it failed because the URI was created lowercase but [the code requires uppercase](https://github.com/Spomky-Labs/otphp/blob/072739fe328d68a7467a90b71937decb83701840/src/OTP.php#L111)