### PR TITLE
Implement TOTP T0 (epoch) parameter according to RFC 6238

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ echo "<img src='{$googleChartUri}'>";
 Now that your applications are configured, you can verify the generated OTPs:
 
 ```php
-$otp->verify($input); // Returns true if the input is verified, otherwize false.
+$otp->verify($input); // Returns true if the input is verified, otherwise false.
 ```
 
 ## Advanced Features

--- a/src/TOTP.php
+++ b/src/TOTP.php
@@ -147,7 +147,7 @@ final class TOTP extends OTP implements TOTPInterface
      */
     private function timecode(int $timestamp): int
     {
-        return (int) ((($timestamp * 1000) / ($this->getPeriod() * 1000)));
+        return (int) floor($timestamp / $this->getPeriod());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT
| Tests added   |  yes
| Doc PR        |  included

This adds support to specify the TOTP `T0` (epoch) parameter according to the specifications in RFC 6238. Example use case included in the docs.
