### PR TITLE
Remove closed gemnasium.com service link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Help me out for a couple of :beers:!
 
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Spomky-Labs/otphp/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Spomky-Labs/otphp/?branch=master)
 [![Coverage Status](https://coveralls.io/repos/Spomky-Labs/otphp/badge.svg?branch=master&service=github)](https://coveralls.io/github/Spomky-Labs/otphp?branch=master)
-[![Dependency Status](https://beta.gemnasium.com/badges/github.com/Spomky-Labs/otphp.svg)](https://beta.gemnasium.com/projects/github.com/Spomky-Labs/otphp)
 
 [![Build Status](https://travis-ci.org/Spomky-Labs/otphp.svg?branch=master)](https://travis-ci.org/Spomky-Labs/otphp)
 [![PHP 7 ready](http://php7ready.timesplinter.ch/Spomky-Labs/otphp/badge.svg)](https://travis-ci.org/Spomky-Labs/otphp)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | maybe?
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Tests added   |  
| Doc PR        |  

https://gemnasium.com has closed and is now part of gitlab.com, the badge appears as a broken image in the readme now.