### PR TITLE
Fix random_compat on php 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "beberlei/assert": "^2.4",
         "symfony/polyfill-mbstring": "^1.1",
         "symfony/polyfill-php56": "^1.1",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": ">=2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0|^5.0",


### PR DESCRIPTION
random_compat on php7 can only install version 9.99.99 (which is a noop version). Requiring >=2 allows 2.0 to install on php5 while allowing 9.99.99 on php7+. See: https://github.com/paragonie/random_compat#version-conflict-with-other-php-project

| Q             | A
| ------------- | ---
| Branch?       | v8.3
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT
| Tests added   |  
| Doc PR        |  


random_compat on php7 can only install version 9.99.99 (which is a noop version). Requiring >=2 allows 2.0 to install on php5 while allowing 9.99.99 on php7+. See: https://github.com/paragonie/random_compat#version-conflict-with-other-php-project