### PR TITLE
Fix issue of case sensitive algorithms

### DIFF
--- a/src/ParameterTrait.php
+++ b/src/ParameterTrait.php
@@ -212,6 +212,7 @@ trait ParameterTrait
                 return $value;
             },
             'algorithm' => function ($value) {
+                $value = strtolower($value);
                 Assertion::inArray($value, hash_algos(), sprintf('The "%s" digest is not supported.', $value));
 
                 return $value;


### PR DESCRIPTION
There is an issue where if loading a provisioning URL with the algorithm in uppercase that an exception is thrown even though the algorithm is valid. This one liner fixes the issue by lowercasing the algorithm name before checking and setting.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | Didn't check (no time sorry)
| Fixed tickets | No issue filed
| License       | MIT


Failing test code as follows due to algorithm=**SHA1**
```
<?php
require_once 'vendor/autoload.php';
use OTPHP\Factory;

$code = 'otpauth://totp/alice%40google.com?secret=JBSWY3DPEHPK3PXP&foo=bar&algorithm=SHA1';
$otp = Factory::loadFromProvisioningUri($code);

echo 'Current OTP: ' . $otp->now();

```