### PR TITLE
Allow thecodingmachine/safe major version 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-mbstring": "*",
         "paragonie/constant_time_encoding": "^2.0",
         "beberlei/assert": "^3.0",
-        "thecodingmachine/safe": "^0.1.14|^1.0"
+        "thecodingmachine/safe": "^0.1.14|^1.0|^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v10.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Tests added   |  <!--highly recommended for new features-->
| Doc PR        |  <!--highly recommended for new features-->

Looks like `v10` is compatible with major version 2 of `thecodingmachine/safe`.