### PR TITLE
[RFC] TOTP doesn't match TOTPInterface

### DIFF
--- a/src/TOTP.php
+++ b/src/TOTP.php
@@ -21,7 +21,7 @@ final class TOTP extends OTP implements TOTPInterface
         string $digest = 'sha1',
         int $digits = 6,
         int $epoch = 0
-    ): TOTPInterface {
+    ): self {
         return new self($secret, $period, $digest, $digits, $epoch);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | v11.0
| Bug fix?      | Yes
| New feature?  | No
| Deprecations? | No
| Tickets       | N/A
| License       | MIT

First up, thanks for maintaining this!

I noticed after updating to v11 (which included replaced TOTP window with
leeway parameter) that the following code no longer satisfies my PHPStan
static analysis.

```
use OTPHP/TOTP;
$totp = TOTP::create($Secret);
$Verify = $totp->verify($In['otp'], leeway: 20);
```

The problem is that `TOTP::create()` returns a `TOTPInterface`,
which extends `OTPInterface`. `OTPInterface->verify()` has a window parameter,
and not a leeway parameter.

I've done a minimally invasive fix here (only for TOTP), but looking
at the code, the interfaces don't match the functions in other areas
as well.

My honest opinion is that most of the interfaces are a liability here.
We already have an abstract OTP class implementing the common methods
and we can define abstrac methods there to force extending classes to
implement methods required for the factory.

If you're open to it, I would be happy to put together a different
pull request to demonstrate.