### PR TITLE
Deprecate `::create` API, add `::createFromSecret` and `::generate` APIs

### DIFF
--- a/doc/AppConfig.md
+++ b/doc/AppConfig.md
@@ -92,13 +92,11 @@ Now run the following and compare the output
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::createFromSecret(
-    'JBSWY3DPEHPK3PXP', // New TOTP with custom secret
-    10,                 // The period (int)
-    'sha512',           // The digest algorithm (string)
-    8                   // The number of digits (int)
-);
-$totp->setLabel('alice@google.com'); // The label (string)
+$totp = TOTP::createFromSecret('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
+$totp->setPeriod(10);                   // The period (int)
+$totp->setDigest('sha512');             // The digest algorithm (string)
+$totp->setDigits(8);                    // The number of digits (int)
+$totp->setLabel('alice@google.com');    // The label (string)
 
 echo 'Current OTP: ' . $totp->now();
 ```

--- a/doc/AppConfig.md
+++ b/doc/AppConfig.md
@@ -15,7 +15,7 @@ You just have to:
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
+$totp = TOTP::createFromSecret('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
 $totp->setLabel('alice@google.com'); // The label (string)
 
 $totp->getProvisioningUri(); // Will return otpauth://totp/alice%40google.com?secret=JBSWY3DPEHPK3PXP
@@ -34,7 +34,7 @@ Hereafter two examples using the Google Chart API (this API is deprecated since 
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create(); // New TOTP
+$totp = TOTP::generate(); // New TOTP
 $totp->setLabel('alice@google.com'); // The label (string)
 
 $google_chart = $totp->getQrCodeUri('https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl={PROVISIONING_URI}', '{PROVISIONING_URI}');
@@ -48,7 +48,7 @@ Please note that this URI MUST contain a placeholder for the OTP Provisioning UR
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create(); // New TOTP
+$totp = TOTP::generate(); // New TOTP
 $totp->setLabel('alice@google.com'); // The label (string)
 
 $goqr_me = $totp->getQrCodeUri(
@@ -74,7 +74,7 @@ Now run the following and compare the output
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
+$totp = TOTP::createFromSecret('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
 $totp->setLabel('alice@google.com'); // The label (string)
 
 echo 'Current OTP: ' . $totp->now();
@@ -92,7 +92,7 @@ Now run the following and compare the output
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create(
+$totp = TOTP::createFromSecret(
     'JBSWY3DPEHPK3PXP', // New TOTP with custom secret
     10,                 // The period (int)
     'sha512',           // The digest algorithm (string)

--- a/doc/Customize.md
+++ b/doc/Customize.md
@@ -21,7 +21,7 @@ use OTPHP\TOTP;
 use ParagonIE\ConstantTime\Base32;
 
 $mySecret = trim(Base32::encodeUpper(random_bytes(128)), '='); // We generate our own 1024 bits secret
-$otp = TOTP::create($mySecret);
+$otp = TOTP::createFromSecret($mySecret);
 ```
 
 *Please note that the trailing `=` are automatically removed by the library.*
@@ -35,13 +35,11 @@ By default, the period for a TOTP is 30 seconds and the counter for a HOTP is 0.
 use OTPHP\TOTP;
 use OTPHP\HOTP;
 
-$otp = TOTP::create(
-    null, // Let the secret be defined by the class
+$otp = TOTP::generate(
     10    // The period is now 10 seconds
 );
 
-$otp = HOTP::create(
-    null, // Let the secret be defined by the class
+$otp = HOTP::generate(
     1000  // The counter is now 1000. We recommend you start at `0`, but you can set any value (at least 0)
 );
 ```
@@ -59,8 +57,7 @@ You must verify that the algorithm you want to use is supported by the applicati
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create(
-    null,       // Let the secret be defined by the class
+$totp = TOTP::generate(
     30,         // The period (30 seconds)
     'ripemd160' // The digest algorithm
 );
@@ -75,8 +72,7 @@ You can decide to use more (or less) digits. More than 10 may be difficult to us
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create(
-    null,   // Let the secret be defined by the class
+$totp = TOTP::generate(
     30,     // The period (30 seconds)
     'sha1', // The digest algorithm
     8       // The output will generate 8 digits
@@ -100,8 +96,7 @@ example encode the timestamp in the secret to make it different each time.
 use OTPHP\TOTP;
 
 // Without epoch
-$otp = TOTP::create(
-    null, // Let the secret be defined by the class
+$otp = TOTP::generate(
     5,     // The period (5 seconds)
     'sha1', // The digest algorithm
     6      // The output will generate 6 digits
@@ -113,8 +108,7 @@ $otp->verify($password, 1519401289); // Second 1: true
 $otp->verify($password, 1519401290); // Second 2: false
 
 // With epoch
-$otp = TOTP::create(
-    null, // Let the secret be defined by the class
+$otp = TOTP::generate(
     5,     // The period (5 seconds)
     'sha1', // The digest algorithm
     6,      // The output will generate 6 digits
@@ -140,7 +134,7 @@ These parameters are available in the provisioning URI or from the method `getPa
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create('JBSWY3DPEHPK3PXP'); // New TOTP
+$totp = TOTP::createFromSecret('JBSWY3DPEHPK3PXP'); // New TOTP
 $totp->setLabel('alice@google.com'); // The label
 $totp->setParameter('foo', 'bar');
 
@@ -156,7 +150,7 @@ it is useful to set the issuer parameter to identify the service that provided t
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
+$totp = TOTP::createFromSecret('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
 $totp->setLabel('alice@google.com'); // The label (string)
 $totp->setIssuer('My Service');
 ```
@@ -187,7 +181,7 @@ Some applications such as FreeOTP can load images from an URI (`image` parameter
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
+$totp = TOTP::createFromSecret('JBSWY3DPEHPK3PXP'); // New TOTP with custom secret
 $totp->setLabel('alice@google.com'); // The label (string)
 $totp->setParameter('image', 'https://foo.bar/otp.png');
 

--- a/doc/Customize.md
+++ b/doc/Customize.md
@@ -35,13 +35,11 @@ By default, the period for a TOTP is 30 seconds and the counter for a HOTP is 0.
 use OTPHP\TOTP;
 use OTPHP\HOTP;
 
-$otp = TOTP::generate(
-    10    // The period is now 10 seconds
-);
+$otp = TOTP::generate();
+$otp->setPeriod(10);    // The period is now 10 seconds
 
-$otp = HOTP::generate(
-    1000  // The counter is now 1000. We recommend you start at `0`, but you can set any value (at least 0)
-);
+$otp = HOTP::generate();
+$otp->setCounter(1000); // The counter is now 1000. We recommend you start at `0`, but you can set any value (at least 0)
 ```
 
 ## Digest
@@ -57,10 +55,9 @@ You must verify that the algorithm you want to use is supported by the applicati
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::generate(
-    30,         // The period (30 seconds)
-    'ripemd160' // The digest algorithm
-);
+$totp = TOTP::generate();
+$totp->setPeriod(30);           // The period (30 seconds)
+$totp->setDigest('ripemd160');  // The digest algorithm
 ```
 
 ## Digits
@@ -72,11 +69,10 @@ You can decide to use more (or less) digits. More than 10 may be difficult to us
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::generate(
-    30,     // The period (30 seconds)
-    'sha1', // The digest algorithm
-    8       // The output will generate 8 digits
-);
+$totp = TOTP::generate();
+$totp->setPeriod(30);       // The period (30 seconds)
+$totp->setDigest('sha1');   // The digest algorithm
+$totp->setDigits(8);        // The output will generate 8 digits
 ```
 
 ## Epoch (TOTP only)
@@ -96,11 +92,10 @@ example encode the timestamp in the secret to make it different each time.
 use OTPHP\TOTP;
 
 // Without epoch
-$otp = TOTP::generate(
-    5,     // The period (5 seconds)
-    'sha1', // The digest algorithm
-    6      // The output will generate 6 digits
-);
+$otp = TOTP::generate();
+$otp->setPeriod(5);         // The period (5 seconds)
+$otp->setDigest('sha1');    // The digest algorithm
+$otp->setDigits(6);         // The output will generate 6 digits
 
 $password = $otp->at(1519401289); // Current period is: 1519401285 - 1519401289
 
@@ -108,12 +103,11 @@ $otp->verify($password, 1519401289); // Second 1: true
 $otp->verify($password, 1519401290); // Second 2: false
 
 // With epoch
-$otp = TOTP::generate(
-    5,     // The period (5 seconds)
-    'sha1', // The digest algorithm
-    6,      // The output will generate 6 digits
-    1519401289 // The epoch is now 02/23/2018 @ 3:54:49pm (UTC)
-);
+$otp = TOTP::generate();
+$otp->setPeriod(5);         // The period (30 seconds)
+$otp->setDigest('sha1');    // The digest algorithm
+$otp->setDigits(6);         // The output will generate 8 digits
+$otp->setEpoch(1519401289); // The epoch is now 02/23/2018 @ 3:54:49pm (UTC)
 
 $password = $otp->at(1519401289);  // Current period is: 1519401289 - 1519401293
 

--- a/doc/QA.md
+++ b/doc/QA.md
@@ -24,7 +24,7 @@ $digits = 6;
 $digest = 'sha1';
 $period = 30;
 
-$totp = TOTP::create(
+$totp = TOTP::createFromSecret(
     $user->getOtpSecret(),
     $period,
     $digest,
@@ -76,7 +76,7 @@ If you try the following code lines, you may see 2 different OTPs.
 <?php
 use OTPHP\TOTP;
 
-$totp = TOTP::create(null, 10); // TOTP with an 10 seconds period
+$totp = TOTP::generate(10); // TOTP with an 10 seconds period
 
 for ($i = 0; $i < 10; $i++) {
     echo 'Current OTP is: '. $totp->now();

--- a/doc/QA.md
+++ b/doc/QA.md
@@ -24,12 +24,10 @@ $digits = 6;
 $digest = 'sha1';
 $period = 30;
 
-$totp = TOTP::createFromSecret(
-    $user->getOtpSecret(),
-    $period,
-    $digest,
-    $digits
-);
+$totp = TOTP::createFromSecret($user->getOtpSecret());
+$totp->setPeriod($period);
+$totp->setDigest($digest);
+$totp->setDigits($digits);
 $totp->setLabel($user->getEmail());
 
 $totp->verify($_POST['otp']);

--- a/doc/index.md
+++ b/doc/index.md
@@ -42,13 +42,13 @@ use OTPHP\TOTP;
 
 // A random secret will be generated from this.
 // You should store the secret with the user for verification.
-$otp = TOTP::create();
+$otp = TOTP::generate();
 echo "The OTP secret is: {$otp->getSecret()}\n";
 
 // Note: use your own way to load the user secret.
 // The function "load_user_secret" is simply a placeholder.
 $secret = load_user_secret();
-$otp = TOTP::create($secret);
+$otp = TOTP::createFromSecret($secret);
 echo "The current OTP is: {$otp->now()}\n";
 ```
 
@@ -74,7 +74,7 @@ echo "<img src='{$grCodeUri}'>";
 Now that your applications are configured, you can verify the generated OTPs:
 
 ```php
-$otp = TOTP::create($secret); // create TOTP object from the secret.
+$otp = TOTP::createFromSecret($secret); // create TOTP object from the secret.
 $otp->verify($input); // Returns true if the input is verified, otherwise false.
 ```
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
         - tests
     ignoreErrors:
         - '#Variable property access on \$this\(OTPHP\\OTP\)\.#'
+        - '#^Method OTPHP\\OTP::generateSecret\(\) should return non-empty-string but returns string\.$#'
 
 includes:
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -62,12 +62,12 @@ final class Factory implements FactoryInterface
     {
         switch ($parsed_url->getHost()) {
             case 'totp':
-                $totp = TOTP::create($parsed_url->getSecret());
+                $totp = TOTP::createFromSecret($parsed_url->getSecret());
                 $totp->setLabel(self::getLabel($parsed_url->getPath()));
 
                 return $totp;
             case 'hotp':
-                $hotp = HOTP::create($parsed_url->getSecret());
+                $hotp = HOTP::createFromSecret($parsed_url->getSecret());
                 $hotp->setLabel(self::getLabel($parsed_url->getPath()));
 
                 return $hotp;

--- a/src/HOTP.php
+++ b/src/HOTP.php
@@ -6,7 +6,6 @@ namespace OTPHP;
 
 use InvalidArgumentException;
 use function is_int;
-use ParagonIE\ConstantTime\Base32;
 
 /**
  * @see \OTPHP\Test\HOTPTest
@@ -39,9 +38,7 @@ final class HOTP extends OTP implements HOTPInterface
 
     public static function generate(int $counter = 0, string $digest = 'sha1', int $digits = 6): self
     {
-        $secret = Base32::encodeUpper(random_bytes(64));
-
-        return new self($secret, $counter, $digest, $digits);
+        return new self(self::generateSecret(), $counter, $digest, $digits);
     }
 
     public function getCounter(): int

--- a/src/HOTP.php
+++ b/src/HOTP.php
@@ -12,33 +12,36 @@ use function is_int;
  */
 final class HOTP extends OTP implements HOTPInterface
 {
-    protected function __construct(null|string $secret, int $counter, string $digest, int $digits)
-    {
-        parent::__construct($secret, $digest, $digits);
-        $this->setCounter($counter);
-    }
-
     public static function create(
         null|string $secret = null,
-        int $counter = 0,
-        string $digest = 'sha1',
-        int $digits = 6
+        int $counter = self::DEFAULT_COUNTER,
+        string $digest = self::DEFAULT_DIGEST,
+        int $digits = self::DEFAULT_DIGITS
     ): self {
-        return new self($secret, $counter, $digest, $digits);
+        $htop = $secret !== null
+            ? self::createFromSecret($secret)
+            : self::generate()
+        ;
+        $htop->setCounter($counter);
+        $htop->setDigest($digest);
+        $htop->setDigits($digits);
+
+        return $htop;
     }
 
-    public static function createFromSecret(
-        string $secret,
-        int $counter = 0,
-        string $digest = 'sha1',
-        int $digits = 6
-    ): self {
-        return new self($secret, $counter, $digest, $digits);
-    }
-
-    public static function generate(int $counter = 0, string $digest = 'sha1', int $digits = 6): self
+    public static function createFromSecret(string $secret): self
     {
-        return new self(self::generateSecret(), $counter, $digest, $digits);
+        $htop = new self($secret);
+        $htop->setCounter(self::DEFAULT_COUNTER);
+        $htop->setDigest(self::DEFAULT_DIGEST);
+        $htop->setDigits(self::DEFAULT_DIGITS);
+
+        return $htop;
+    }
+
+    public static function generate(): self
+    {
+        return self::createFromSecret(self::generateSecret());
     }
 
     public function getCounter(): int
@@ -72,7 +75,7 @@ final class HOTP extends OTP implements HOTPInterface
         return $this->verifyOtpWithWindow($otp, $counter, $window);
     }
 
-    protected function setCounter(int $counter): void
+    public function setCounter(int $counter): void
     {
         $this->setParameter('counter', $counter);
     }

--- a/src/HOTP.php
+++ b/src/HOTP.php
@@ -6,6 +6,7 @@ namespace OTPHP;
 
 use InvalidArgumentException;
 use function is_int;
+use ParagonIE\ConstantTime\Base32;
 
 /**
  * @see \OTPHP\Test\HOTPTest
@@ -24,6 +25,22 @@ final class HOTP extends OTP implements HOTPInterface
         string $digest = 'sha1',
         int $digits = 6
     ): self {
+        return new self($secret, $counter, $digest, $digits);
+    }
+
+    public static function createFromSecret(
+        string $secret,
+        int $counter = 0,
+        string $digest = 'sha1',
+        int $digits = 6
+    ): self {
+        return new self($secret, $counter, $digest, $digits);
+    }
+
+    public static function generate(int $counter = 0, string $digest = 'sha1', int $digits = 6): self
+    {
+        $secret = Base32::encodeUpper(random_bytes(64));
+
         return new self($secret, $counter, $digest, $digits);
     }
 

--- a/src/HOTPInterface.php
+++ b/src/HOTPInterface.php
@@ -15,6 +15,8 @@ interface HOTPInterface extends OTPInterface
      * Create a new HOTP object.
      *
      * If the secret is null, a random 64 bytes secret will be generated.
+     *
+     * @deprecated Deprecated since v11.1, use ::createFromSecret or ::generate instead
      */
     public static function create(
         null|string $secret = null,

--- a/src/HOTPInterface.php
+++ b/src/HOTPInterface.php
@@ -6,6 +6,8 @@ namespace OTPHP;
 
 interface HOTPInterface extends OTPInterface
 {
+    public const DEFAULT_COUNTER = 0;
+
     /**
      * The initial counter (a positive integer).
      */
@@ -16,6 +18,9 @@ interface HOTPInterface extends OTPInterface
      *
      * If the secret is null, a random 64 bytes secret will be generated.
      *
+     * @param null|non-empty-string $secret
+     * @param non-empty-string $digest
+     *
      * @deprecated Deprecated since v11.1, use ::createFromSecret or ::generate instead
      */
     public static function create(
@@ -25,20 +30,5 @@ interface HOTPInterface extends OTPInterface
         int $digits = 6
     ): self;
 
-    /**
-     * Create a TOTP object from an existing secret.
-     *
-     * @param non-empty-string $secret
-     */
-    public static function createFromSecret(
-        string $secret,
-        int $counter = 0,
-        string $digest = 'sha1',
-        int $digits = 6
-    ): self;
-
-    /**
-     * Create a new HOTP object. A random 64 bytes secret will be generated.
-     */
-    public static function generate(int $counter = 0, string $digest = 'sha1', int $digits = 6): self;
+    public function setCounter(int $counter): void;
 }

--- a/src/HOTPInterface.php
+++ b/src/HOTPInterface.php
@@ -12,7 +12,7 @@ interface HOTPInterface extends OTPInterface
     public function getCounter(): int;
 
     /**
-     * Create a new TOTP object.
+     * Create a new HOTP object.
      *
      * If the secret is null, a random 64 bytes secret will be generated.
      */
@@ -22,4 +22,21 @@ interface HOTPInterface extends OTPInterface
         string $digest = 'sha1',
         int $digits = 6
     ): self;
+
+    /**
+     * Create a TOTP object from an existing secret.
+     *
+     * @param non-empty-string $secret
+     */
+    public static function createFromSecret(
+        string $secret,
+        int $counter = 0,
+        string $digest = 'sha1',
+        int $digits = 6
+    ): self;
+
+    /**
+     * Create a new HOTP object. A random 64 bytes secret will be generated.
+     */
+    public static function generate(int $counter = 0, string $digest = 'sha1', int $digits = 6): self;
 }

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -37,6 +37,14 @@ abstract class OTP implements OTPInterface
     }
 
     /**
+     * @return non-empty-string
+     */
+    final protected static function generateSecret(): string
+    {
+        return Base32::encodeUpper(random_bytes(64));
+    }
+
+    /**
      * The OTP at the specified input.
      */
     protected function generateOTP(int $input): string

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -17,11 +17,12 @@ abstract class OTP implements OTPInterface
 {
     use ParameterTrait;
 
-    protected function __construct(null|string $secret, string $digest, int $digits)
+    /**
+     * @param non-empty-string $secret
+     */
+    protected function __construct(string $secret)
     {
         $this->setSecret($secret);
-        $this->setDigest($digest);
-        $this->setDigits($digits);
     }
 
     public function getQrCodeUri(string $uri, string $placeholder): string

--- a/src/OTPInterface.php
+++ b/src/OTPInterface.php
@@ -6,6 +6,34 @@ namespace OTPHP;
 
 interface OTPInterface
 {
+    public const DEFAULT_DIGITS = 6;
+
+    public const DEFAULT_DIGEST = 'sha1';
+
+    /**
+     * Create a OTP object from an existing secret.
+     *
+     * @param non-empty-string $secret
+     */
+    public static function createFromSecret(string $secret): self;
+
+    /**
+     * Create a new OTP object. A random 64 bytes secret will be generated.
+     */
+    public static function generate(): self;
+
+    /**
+     * @param non-empty-string $secret
+     */
+    public function setSecret(string $secret): void;
+
+    public function setDigits(int $digits): void;
+
+    /**
+     * @param non-empty-string $digest
+     */
+    public function setDigest(string $digest): void;
+
     /**
      * @return string Return the OTP at the specified timestamp
      */

--- a/src/ParameterTrait.php
+++ b/src/ParameterTrait.php
@@ -121,6 +121,21 @@ trait ParameterTrait
         }
     }
 
+    public function setSecret(string $secret): void
+    {
+        $this->setParameter('secret', $secret);
+    }
+
+    public function setDigits(int $digits): void
+    {
+        $this->setParameter('digits', $digits);
+    }
+
+    public function setDigest(string $digest): void
+    {
+        $this->setParameter('algorithm', $digest);
+    }
+
     /**
      * @return array<string, callable>
      */
@@ -159,21 +174,6 @@ trait ParameterTrait
                 return $value;
             },
         ];
-    }
-
-    private function setSecret(null|string $secret): void
-    {
-        $this->setParameter('secret', $secret);
-    }
-
-    private function setDigits(int $digits): void
-    {
-        $this->setParameter('digits', $digits);
-    }
-
-    private function setDigest(string $digest): void
-    {
-        $this->setParameter('algorithm', $digest);
     }
 
     private function hasColon(string $value): bool

--- a/src/ParameterTrait.php
+++ b/src/ParameterTrait.php
@@ -9,7 +9,6 @@ use function in_array;
 use InvalidArgumentException;
 use function is_int;
 use function is_string;
-use ParagonIE\ConstantTime\Base32;
 
 trait ParameterTrait
 {
@@ -136,10 +135,6 @@ trait ParameterTrait
                 return $value;
             },
             'secret' => static function ($value): string {
-                if ($value === null) {
-                    $value = Base32::encodeUpper(random_bytes(64));
-                }
-
                 return mb_strtoupper(trim($value, '='));
             },
             'algorithm' => static function ($value): string {

--- a/src/TOTP.php
+++ b/src/TOTP.php
@@ -6,6 +6,7 @@ namespace OTPHP;
 
 use InvalidArgumentException;
 use function is_int;
+use ParagonIE\ConstantTime\Base32;
 
 /**
  * @see \OTPHP\Test\TOTPTest
@@ -26,6 +27,27 @@ final class TOTP extends OTP implements TOTPInterface
         int $digits = 6,
         int $epoch = 0
     ): self {
+        return new self($secret, $period, $digest, $digits, $epoch);
+    }
+
+    public static function createFromSecret(
+        string $secret,
+        int $period = 30,
+        string $digest = 'sha1',
+        int $digits = 6,
+        int $epoch = 0
+    ): self {
+        return new self($secret, $period, $digest, $digits, $epoch);
+    }
+
+    public static function generate(
+        int $period = 30,
+        string $digest = 'sha1',
+        int $digits = 6,
+        int $epoch = 0
+    ): self {
+        $secret = Base32::encodeUpper(random_bytes(64));
+
         return new self($secret, $period, $digest, $digits, $epoch);
     }
 

--- a/src/TOTP.php
+++ b/src/TOTP.php
@@ -6,7 +6,6 @@ namespace OTPHP;
 
 use InvalidArgumentException;
 use function is_int;
-use ParagonIE\ConstantTime\Base32;
 
 /**
  * @see \OTPHP\Test\TOTPTest
@@ -46,9 +45,7 @@ final class TOTP extends OTP implements TOTPInterface
         int $digits = 6,
         int $epoch = 0
     ): self {
-        $secret = Base32::encodeUpper(random_bytes(64));
-
-        return new self($secret, $period, $digest, $digits, $epoch);
+        return new self(self::generateSecret(), $period, $digest, $digits, $epoch);
     }
 
     public function getPeriod(): int

--- a/src/TOTPInterface.php
+++ b/src/TOTPInterface.php
@@ -19,6 +19,23 @@ interface TOTPInterface extends OTPInterface
     ): self;
 
     /**
+     * Create a TOTP object from an existing secret.
+     *
+     * @param non-empty-string $secret
+     */
+    public static function createFromSecret(
+        string $secret,
+        int $period = 30,
+        string $digest = 'sha1',
+        int $digits = 6
+    ): self;
+
+    /**
+     * Create a new TOTP object. A random 64 bytes secret will be generated.
+     */
+    public static function generate(int $period = 30, string $digest = 'sha1', int $digits = 6): self;
+
+    /**
      * Return the TOTP at the current time.
      */
     public function now(): string;

--- a/src/TOTPInterface.php
+++ b/src/TOTPInterface.php
@@ -10,6 +10,8 @@ interface TOTPInterface extends OTPInterface
      * Create a new TOTP object.
      *
      * If the secret is null, a random 64 bytes secret will be generated.
+     *
+     * @deprecated Deprecated since v11.1, use ::createFromSecret or ::generate instead
      */
     public static function create(
         null|string $secret = null,

--- a/src/TOTPInterface.php
+++ b/src/TOTPInterface.php
@@ -6,36 +6,30 @@ namespace OTPHP;
 
 interface TOTPInterface extends OTPInterface
 {
+    public const DEFAULT_PERIOD = 30;
+
+    public const DEFAULT_EPOCH = 0;
+
     /**
      * Create a new TOTP object.
      *
      * If the secret is null, a random 64 bytes secret will be generated.
      *
+     * @param null|non-empty-string $secret
+     * @param non-empty-string $digest
+     *
      * @deprecated Deprecated since v11.1, use ::createFromSecret or ::generate instead
      */
     public static function create(
         null|string $secret = null,
-        int $period = 30,
-        string $digest = 'sha1',
-        int $digits = 6
+        int $period = self::DEFAULT_PERIOD,
+        string $digest = self::DEFAULT_DIGEST,
+        int $digits = self::DEFAULT_DIGITS
     ): self;
 
-    /**
-     * Create a TOTP object from an existing secret.
-     *
-     * @param non-empty-string $secret
-     */
-    public static function createFromSecret(
-        string $secret,
-        int $period = 30,
-        string $digest = 'sha1',
-        int $digits = 6
-    ): self;
+    public function setPeriod(int $period): void;
 
-    /**
-     * Create a new TOTP object. A random 64 bytes secret will be generated.
-     */
-    public static function generate(int $period = 30, string $digest = 'sha1', int $digits = 6): self;
+    public function setEpoch(int $epoch): void;
 
     /**
      * Return the TOTP at the current time.

--- a/src/Url.php
+++ b/src/Url.php
@@ -13,6 +13,9 @@ use function is_string;
  */
 final class Url
 {
+    /**
+     * @param non-empty-string $secret
+     */
     public function __construct(
         private readonly string $scheme,
         private readonly string $host,
@@ -38,6 +41,9 @@ final class Url
         return $this->path;
     }
 
+    /**
+     * @return non-empty-string
+     */
     public function getSecret(): string
     {
         return $this->secret;

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -21,7 +21,7 @@ final class HOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The label is not set.');
-        $hotp = HOTP::create();
+        $hotp = HOTP::generate();
         $hotp->getProvisioningUri();
     }
 
@@ -32,7 +32,7 @@ final class HOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Issuer must not contain a colon.');
-        $otp = HOTP::create('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
         $otp->setLabel('alice');
         $otp->setIssuer('foo%3Abar');
     }
@@ -44,7 +44,7 @@ final class HOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Issuer must not contain a colon.');
-        $otp = HOTP::create('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
         $otp->setLabel('alice');
         $otp->setIssuer('foo%3abar');
     }
@@ -56,7 +56,7 @@ final class HOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Label must not contain a colon.');
-        $otp = HOTP::create('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
         $otp->setLabel('foo%3Abar');
         $otp->getProvisioningUri();
     }
@@ -68,7 +68,7 @@ final class HOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Label must not contain a colon.');
-        $otp = HOTP::create('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
+        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
         $otp->setLabel('foo:bar');
         $otp->getProvisioningUri();
     }
@@ -80,7 +80,7 @@ final class HOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Digits must be at least 1.');
-        HOTP::create('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 0);
+        HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 0);
     }
 
     /**
@@ -90,7 +90,7 @@ final class HOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Counter must be at least 0.');
-        HOTP::create('JDDK4U6G3BJLEZ7Y', -500);
+        HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', -500);
     }
 
     /**
@@ -100,7 +100,7 @@ final class HOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" digest is not supported.');
-        HOTP::create('JDDK4U6G3BJLEZ7Y', 0, 'foo');
+        HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'foo');
     }
 
     /**
@@ -114,7 +114,7 @@ final class HOTPTest extends TestCase
         $this->expectExceptionMessage('Unable to decode the secret. Is it correctly base32 encoded?');
         $secret = random_bytes(32);
 
-        $otp = HOTP::create($secret);
+        $otp = HOTP::createFromSecret($secret);
         $otp->at(0);
     }
 
@@ -123,7 +123,7 @@ final class HOTPTest extends TestCase
      */
     public function objectCreationValid(): void
     {
-        $otp = HOTP::create();
+        $otp = HOTP::generate();
 
         static::assertMatchesRegularExpression('/^[A-Z2-7]+$/', $otp->getSecret());
     }
@@ -184,7 +184,9 @@ final class HOTPTest extends TestCase
         string $label = 'alice@foo.bar',
         string $issuer = 'My Project'
     ): HOTP {
-        $otp = HOTP::create($secret, $counter, $digest, $digits);
+        static::assertNotSame('', $secret);
+
+        $otp = HOTP::createFromSecret($secret, $counter, $digest, $digits);
         $otp->setLabel($label);
         $otp->setIssuer($issuer);
 

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -30,10 +30,10 @@ final class HOTPTest extends TestCase
      */
     public function issuerHasColon(): void
     {
+        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Issuer must not contain a colon.');
-        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
-        $otp->setLabel('alice');
         $otp->setIssuer('foo%3Abar');
     }
 
@@ -42,10 +42,10 @@ final class HOTPTest extends TestCase
      */
     public function issuerHasColon2(): void
     {
+        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Issuer must not contain a colon.');
-        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
-        $otp->setLabel('alice');
         $otp->setIssuer('foo%3abar');
     }
 
@@ -54,11 +54,11 @@ final class HOTPTest extends TestCase
      */
     public function labelHasColon(): void
     {
+        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Label must not contain a colon.');
-        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
         $otp->setLabel('foo%3Abar');
-        $otp->getProvisioningUri();
     }
 
     /**
@@ -66,11 +66,11 @@ final class HOTPTest extends TestCase
      */
     public function labelHasColon2(): void
     {
+        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Label must not contain a colon.');
-        $otp = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 8);
         $otp->setLabel('foo:bar');
-        $otp->getProvisioningUri();
     }
 
     /**
@@ -78,9 +78,11 @@ final class HOTPTest extends TestCase
      */
     public function digitsIsNot1OrMore(): void
     {
+        $htop = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Digits must be at least 1.');
-        HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'sha512', 0);
+        $htop->setDigits(0);
     }
 
     /**
@@ -88,9 +90,11 @@ final class HOTPTest extends TestCase
      */
     public function counterIsNot1OrMore(): void
     {
+        $htop = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Counter must be at least 0.');
-        HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', -500);
+        $htop->setCounter(-500);
     }
 
     /**
@@ -98,9 +102,11 @@ final class HOTPTest extends TestCase
      */
     public function digestIsNotSupported(): void
     {
+        $htop = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" digest is not supported.');
-        HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 0, 'foo');
+        $htop->setDigest('foo');
     }
 
     /**
@@ -110,11 +116,10 @@ final class HOTPTest extends TestCase
      */
     public function secretShouldBeBase32Encoded(): void
     {
+        $otp = HOTP::createFromSecret(random_bytes(32));
+
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Unable to decode the secret. Is it correctly base32 encoded?');
-        $secret = random_bytes(32);
-
-        $otp = HOTP::createFromSecret($secret);
         $otp->at(0);
     }
 
@@ -185,8 +190,12 @@ final class HOTPTest extends TestCase
         string $issuer = 'My Project'
     ): HOTP {
         static::assertNotSame('', $secret);
+        static::assertNotSame('', $digest);
 
-        $otp = HOTP::createFromSecret($secret, $counter, $digest, $digits);
+        $otp = HOTP::createFromSecret($secret);
+        $otp->setCounter($counter);
+        $otp->setDigest($digest);
+        $otp->setDigits($digits);
         $otp->setLabel($label);
         $otp->setIssuer($issuer);
 

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -33,7 +33,11 @@ final class TOTPTest extends TestCase
      */
     public function customParameter(): void
     {
-        $otp = TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 20, 'sha512', 8, 100);
+        $otp = TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+        $otp->setPeriod(20);
+        $otp->setDigest('sha512');
+        $otp->setDigits(8);
+        $otp->setEpoch(100);
         $otp->setLabel('alice@foo.bar');
         $otp->setIssuer('My Project');
         $otp->setParameter('foo', 'bar.baz');
@@ -59,9 +63,11 @@ final class TOTPTest extends TestCase
      */
     public function periodIsNot1OrMore(): void
     {
+        $totp = TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Period must be at least 1.');
-        TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', -20, 'sha512', 8);
+        $totp->setPeriod(-20);
     }
 
     /**
@@ -69,9 +75,11 @@ final class TOTPTest extends TestCase
      */
     public function epochIsNot0OrMore(): void
     {
+        $totp = TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Epoch must be greater than or equal to 0.');
-        TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 30, 'sha512', 8, -1);
+        $totp->setEpoch(-1);
     }
 
     /**
@@ -403,8 +411,13 @@ final class TOTPTest extends TestCase
         int $epoch = 0
     ): TOTP {
         static::assertNotSame('', $secret);
+        static::assertNotSame('', $digest);
 
-        $otp = TOTP::createFromSecret($secret, $period, $digest, $digits, $epoch);
+        $otp = TOTP::createFromSecret($secret);
+        $otp->setPeriod($period);
+        $otp->setDigest($digest);
+        $otp->setDigits($digits);
+        $otp->setEpoch($epoch);
         $otp->setLabel($label);
         $otp->setIssuer($issuer);
 

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -24,7 +24,7 @@ final class TOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The label is not set.');
-        $otp = TOTP::create();
+        $otp = TOTP::generate();
         $otp->getProvisioningUri();
     }
 
@@ -33,7 +33,7 @@ final class TOTPTest extends TestCase
      */
     public function customParameter(): void
     {
-        $otp = TOTP::create('JDDK4U6G3BJLEZ7Y', 20, 'sha512', 8, 100);
+        $otp = TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 20, 'sha512', 8, 100);
         $otp->setLabel('alice@foo.bar');
         $otp->setIssuer('My Project');
         $otp->setParameter('foo', 'bar.baz');
@@ -49,7 +49,7 @@ final class TOTPTest extends TestCase
      */
     public function objectCreationValid(): void
     {
-        $otp = TOTP::create();
+        $otp = TOTP::generate();
 
         static::assertMatchesRegularExpression('/^[A-Z2-7]+$/', $otp->getSecret());
     }
@@ -61,7 +61,7 @@ final class TOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Period must be at least 1.');
-        TOTP::create('JDDK4U6G3BJLEZ7Y', -20, 'sha512', 8);
+        TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', -20, 'sha512', 8);
     }
 
     /**
@@ -71,7 +71,7 @@ final class TOTPTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Epoch must be greater than or equal to 0.');
-        TOTP::create('JDDK4U6G3BJLEZ7Y', 30, 'sha512', 8, -1);
+        TOTP::createFromSecret('JDDK4U6G3BJLEZ7Y', 30, 'sha512', 8, -1);
     }
 
     /**
@@ -83,7 +83,7 @@ final class TOTPTest extends TestCase
         $this->expectExceptionMessage('Unable to decode the secret. Is it correctly base32 encoded?');
         $secret = random_bytes(32);
 
-        $otp = TOTP::create($secret);
+        $otp = TOTP::createFromSecret($secret);
         $otp->now();
     }
 
@@ -402,7 +402,9 @@ final class TOTPTest extends TestCase
         string $issuer = 'My Project',
         int $epoch = 0
     ): TOTP {
-        $otp = TOTP::create($secret, $period, $digest, $digits, $epoch);
+        static::assertNotSame('', $secret);
+
+        $otp = TOTP::createFromSecret($secret, $period, $digest, $digits, $epoch);
         $otp->setLabel($label);
         $otp->setIssuer($issuer);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `v11`
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #165
| License       | MIT
