### PR TITLE
allow passing a `$secretSize` when generating a secret

### DIFF
--- a/src/HOTP.php
+++ b/src/HOTP.php
@@ -41,9 +41,9 @@ final class HOTP extends OTP implements HOTPInterface
         return $htop;
     }
 
-    public static function generate(): self
+    public static function generate(int $secretSize = null): self
     {
-        return self::createFromSecret(self::generateSecret());
+        return self::createFromSecret(self::generateSecret($secretSize));
     }
 
     public function getCounter(): int

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -43,9 +43,9 @@ abstract class OTP implements OTPInterface
     /**
      * @return non-empty-string
      */
-    final protected static function generateSecret(): string
+    final protected static function generateSecret(int $secretSize = null): string
     {
-        return Base32::encodeUpper(random_bytes(self::DEFAULT_SECRET_SIZE));
+        return Base32::encodeUpper(random_bytes($secretSize ?? self::DEFAULT_SECRET_SIZE));
     }
 
     /**

--- a/src/TOTP.php
+++ b/src/TOTP.php
@@ -62,9 +62,9 @@ final class TOTP extends OTP implements TOTPInterface
         return $totp;
     }
 
-    public static function generate(?ClockInterface $clock = null): self
+    public static function generate(?ClockInterface $clock = null, int $secretSize = null): self
     {
-        return self::createFromSecret(self::generateSecret(), $clock);
+        return self::createFromSecret(self::generateSecret($secretSize), $clock);
     }
 
     public function getPeriod(): int


### PR DESCRIPTION
Target branch: 11.3.x
Resolves issue: none

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

this will allow the user to set their own secret length, but allow the package to still handle the creation of the string.  I think this is a better interface for the user, as this is most likely a large chunk of the reasons someone would want to have a custom secret over the default.

It also helps avoid a (likely) implicit dependency in user code. We are currently using `TOTP::createFromSecret(Base32::encode(Str::random(16)))->getSecret()` to generate a shorter random secret than the default. Here we are using the `Base32` class from `ParagonIE`, even though it is not an explicit dependency in our code. We probably should be, rather than implicitly depend on it. I'm guessing other people may make this mistake as well.

If there's a better architecture way to handle this, open to suggestions.
