### PR TITLE
Explicitly set arg_seperator

### DIFF
--- a/src/OTP.php
+++ b/src/OTP.php
@@ -100,7 +100,7 @@ abstract class OTP implements OTPInterface
         $this->hasColon($label) === false || throw new InvalidArgumentException('Label must not contain a colon.');
         $options = [...$options, ...$this->getParameters()];
         $this->filterOptions($options);
-        $params = str_replace(['+', '%7E'], ['%20', '~'], http_build_query($options));
+        $params = str_replace(['+', '%7E'], ['%20', '~'], http_build_query($options, arg_separator: '&'));
 
         return sprintf(
             'otpauth://%s/%s?%s',

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -110,6 +110,21 @@ final class TOTPTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function getProvisioningUriWithNonDefaultArgSeperator(): void
+    {
+        $otp = self::createTOTP(6, 'sha1', 30);
+
+        ini_set('arg_separator.output', '&amp;');
+
+        static::assertSame(
+            'otpauth://totp/My%20Project%3Aalice%40foo.bar?issuer=My%20Project&secret=JDDK4U6G3BJLEZ7Y',
+            $otp->getProvisioningUri()
+        );
+    }
+
+    /**
      * @param positive-int $timestamp
      * @param positive-int $period
      * @param positive-int $expectedRemainder


### PR DESCRIPTION
We cannot rely on `arg_separator.output` to be set to it's default '&', therefore we explicitly set it here.

Target branch: 11.3.x

<!-- replace space with "x" in square brackets: [x] -->
- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations


