### PR TITLE
Fix http_build_query in OTP class

### DIFF
--- a/src/OTP.php
+++ b/src/OTP.php
@@ -100,7 +100,7 @@ abstract class OTP implements OTPInterface
         $this->hasColon($label) === false || throw new InvalidArgumentException('Label must not contain a colon.');
         $options = [...$options, ...$this->getParameters()];
         $this->filterOptions($options);
-        $params = str_replace(['+', '%7E'], ['%20', '~'], http_build_query($options, arg_separator: '&'));
+        $params = str_replace(['+', '%7E'], ['%20', '~'], http_build_query($options, '', '&'));
 
         return sprintf(
             'otpauth://%s/%s?%s',


### PR DESCRIPTION
The change fixes a syntax issue with http_build_query in OTP class. Specifically, incorrect usage of 'arg_separator' as a keyword argument results in an error. Replaced that incorrect usage with the appropriate way of using this function, improving the reliability and correctness of building the query string.

Target branch: 
Resolves issue # <!-- #-prefixed issue number(s), if any -->

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

<!--
Fill in this template according to the PR you're about to submit.
Replace this comment by a description of what your PR is solving.

Please consider the following requirement:
* Modification of existing tests should be avoided unless deemed necessary.
* You MUST never open a PR related to a security issue. Contact Spomky in private at https://gitter.im/Spomky/
-->
