### PR TITLE
TOTP: introduce new interface that prevents code reuse

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -9,6 +9,7 @@ use Psr\Clock\ClockInterface;
 use Throwable;
 use function assert;
 use function count;
+use function sprintf;
 
 /**
  * This class is used to load OTP object from a provisioning Uri.

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -12,6 +12,7 @@ use function assert;
 use function chr;
 use function count;
 use function is_string;
+use function sprintf;
 use const STR_PAD_LEFT;
 
 abstract class OTP implements OTPInterface

--- a/src/OTPWithPreviousTimestampInterface.php
+++ b/src/OTPWithPreviousTimestampInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OTPHP;
+
+interface OTPWithPreviousTimestampInterface extends OTPInterface
+{
+    /**
+     * Verify method which prevents previously used codes from being used again. The passed values are in seconds.
+     *
+     * @param non-empty-string $otp
+     * @param null|0|positive-int $timestamp
+     * @param null|0|positive-int $leeway
+     * @param null|0|positive-int $previousTimestamp
+     * @return int|false the timestamp matching the otp on success, and false on error
+     */
+    public function verifyWithPreviousTimestamp(
+        string $otp,
+        null|int $timestamp = null,
+        null|int $leeway = null,
+        null|int $previousTimestamp = null
+    ): int|false;
+}

--- a/src/ParameterTrait.php
+++ b/src/ParameterTrait.php
@@ -10,6 +10,7 @@ use function assert;
 use function in_array;
 use function is_int;
 use function is_string;
+use function sprintf;
 
 trait ParameterTrait
 {

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -212,6 +212,31 @@ final class TOTPTest extends TestCase
     }
 
     #[Test]
+    public function verifyOtpWithPreviousTimestamp(): void
+    {
+        $otp = self::createTOTP(6, 'sha1', 30);
+
+        static::assertSame(319_690_800, $otp->verifyWithPreviousTimestamp('762124', 319_690_800, null, 0));
+        static::assertSame(
+            319_690_800,
+            $otp->verifyWithPreviousTimestamp('762124', 319_690_800, null, 319_690_770),
+            'Can use new code'
+        );
+        static::assertFalse(
+            $otp->verifyWithPreviousTimestamp('762124', 319_690_800, null, 319_690_800),
+            'Cannot use same code again'
+        );
+        static::assertFalse(
+            $otp->verifyWithPreviousTimestamp('762124', 319_690_801, null, 319_690_800),
+            'Cannot use same code again at different timestamp'
+        );
+        static::assertFalse(
+            $otp->verifyWithPreviousTimestamp('762124', 319_690_800, null, 319_690_830),
+            'Cannot use previous code'
+        );
+    }
+
+    #[Test]
     public function notCompatibleWithGoogleAuthenticator(): void
     {
         $otp = self::createTOTP(9, 'sha512', 10);


### PR DESCRIPTION
Target branch: 11.4.x
Resolves issue #226

<!-- replace space with "x" in square brackets: [x] -->
- [ ] It is a Bug fix
- [x] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

We did run into the same issue that was previously mentioned [here](https://github.com/Spomky-Labs/otphp/issues/226) where users can submit the same TOTP code multiple times.

To prevent this, a new interface was introduced with a new `verifyWithPreviousTimestamp` method that accepts an additional parameter, the timestamp of the last used code. Passing the parameter will prevent the code matching the timestamp, and in case leeway is used, the previous code, from being reused again. To make it possible to store the timestamp for the submitted code, the timestamp needs to be returned by the `verifyWithPreviousTimestamp` method. Happy to adjust this to return a result object, in case that is preferred.

