### PR TITLE
Allow generateURI to better handle creation with missing label or issuer

### DIFF
--- a/.ci-tools/phpstan-baseline.neon
+++ b/.ci-tools/phpstan-baseline.neon
@@ -235,6 +235,12 @@ parameters:
 			path: ../src/OTP.php
 
 		-
+			rawMessage: 'Method OTPHP\OTP::buildProvisioningUriLabel() should return non-empty-string but returns non-empty-string|null.'
+			identifier: return.type
+			count: 1
+			path: ../src/OTP.php
+
+		-
 			rawMessage: 'Method OTPHP\OTP::compareOTP() is not final, but since the containing class is abstract, it should be.'
 			identifier: ergebnis.finalInAbstractClass
 			count: 1

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -289,25 +289,6 @@ abstract class OTP implements OTPInterface
      */
     protected function generateURI(string $type, array $options): string
     {
-        $issuer = $this->getIssuer();
-        $label = $this->getLabel();
-
-        if (null !== $issuer && !$issuer) {
-            throw new InvalidArgumentException('Issuer must not be an empty string');
-        }
-
-        if (null !== $label && !$label) {
-            throw new InvalidArgumentException('Label must not be an empty string');
-        }
-
-        if (!$issuer && !$label) {
-            throw new InvalidArgumentException('The label is not set. Either label or issuer must be set.');
-        }
-
-        if ($label && $this->hasColon($label)) {
-            throw new InvalidArgumentException('Label must not contain a colon.');
-        }
-
         $options = [...$options, ...$this->getParameters()];
         $this->filterOptions($options);
         $params = str_replace(['+', '%7E'], ['%20', '~'], http_build_query($options, '', '&'));
@@ -315,11 +296,7 @@ abstract class OTP implements OTPInterface
         return sprintf(
             'otpauth://%s/%s?%s',
             $type,
-            rawurlencode(match (true) {
-                null !== $issuer && null !== $label => $issuer.':'.$label,
-                null !== $issuer => $issuer,
-                default => $label,
-            }),
+            rawurlencode($this->buildProvisioningUriLabel()),
             $params
         );
     }
@@ -397,6 +374,27 @@ abstract class OTP implements OTPInterface
         }
 
         return str_pad(implode('', array_reverse($result)), 8, "\000", STR_PAD_LEFT);
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    private function buildProvisioningUriLabel(): string
+    {
+        $issuer = $this->getIssuer();
+        $label = $this->getLabel();
+
+        return match (true) {
+            $issuer === null && $label === null => throw new InvalidArgumentException(
+                'The label is not set. Either label or issuer must be set.'
+            ),
+            $label !== null && $this->hasColon($label) => throw new InvalidArgumentException(
+                'Label must not contain a colon.'
+            ),
+            $issuer !== null && $label !== null => $issuer . ':' . $label,
+            $issuer !== null => $issuer,
+            default => $label,
+        };
     }
 
     /**

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -293,12 +293,7 @@ abstract class OTP implements OTPInterface
         $this->filterOptions($options);
         $params = str_replace(['+', '%7E'], ['%20', '~'], http_build_query($options, '', '&'));
 
-        return sprintf(
-            'otpauth://%s/%s?%s',
-            $type,
-            rawurlencode($this->buildProvisioningUriLabel()),
-            $params
-        );
+        return sprintf('otpauth://%s/%s?%s', $type, rawurlencode($this->buildProvisioningUriLabel()), $params);
     }
 
     /**

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -289,9 +289,25 @@ abstract class OTP implements OTPInterface
      */
     protected function generateURI(string $type, array $options): string
     {
+        $issuer = $this->getIssuer();
         $label = $this->getLabel();
-        is_string($label) || throw new InvalidArgumentException('The label is not set.');
-        $this->hasColon($label) === false || throw new InvalidArgumentException('Label must not contain a colon.');
+
+        if (null !== $issuer && !$issuer) {
+            throw new InvalidArgumentException('Issuer must not be an empty string');
+        }
+
+        if (null !== $label && !$label) {
+            throw new InvalidArgumentException('Label must not be an empty string');
+        }
+
+        if (!$issuer && !$label) {
+            throw new InvalidArgumentException('The label is not set. Either label or issuer must be set.');
+        }
+
+        if ($label && $this->hasColon($label)) {
+            throw new InvalidArgumentException('Label must not contain a colon.');
+        }
+
         $options = [...$options, ...$this->getParameters()];
         $this->filterOptions($options);
         $params = str_replace(['+', '%7E'], ['%20', '~'], http_build_query($options, '', '&'));
@@ -299,7 +315,11 @@ abstract class OTP implements OTPInterface
         return sprintf(
             'otpauth://%s/%s?%s',
             $type,
-            rawurlencode(($this->getIssuer() !== null ? $this->getIssuer() . ':' : '') . $label),
+            rawurlencode(match (true) {
+                null !== $issuer && null !== $label => $issuer.':'.$label,
+                null !== $issuer => $issuer,
+                default => $label,
+            }),
             $params
         );
     }

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -19,9 +19,46 @@ final class HOTPTest extends TestCase
     public function labelNotDefined(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The label is not set.');
+        $this->expectExceptionMessage('The label is not set. Either label or issuer must be set.');
         $hotp = HOTP::generate();
         $hotp->getProvisioningUri();
+    }
+
+    #[Test]
+    public function provisioningUriWithIssuerOnly(): void
+    {
+        $hotp = HOTP::generate();
+        $hotp->setIssuer('My Issuer');
+
+        $uri = $hotp->getProvisioningUri();
+
+        static::assertStringContainsString('otpauth://hotp/My%20Issuer?', $uri);
+        static::assertStringContainsString('issuer=My%20Issuer', $uri);
+    }
+
+    #[Test]
+    public function provisioningUriWithLabelOnly(): void
+    {
+        $hotp = HOTP::generate();
+        $hotp->setLabel('alice@foo.bar');
+
+        $uri = $hotp->getProvisioningUri();
+
+        static::assertStringContainsString('otpauth://hotp/alice%40foo.bar?', $uri);
+        static::assertStringNotContainsString('issuer=', $uri);
+    }
+
+    #[Test]
+    public function provisioningUriWithIssuerAndLabel(): void
+    {
+        $hotp = HOTP::generate();
+        $hotp->setIssuer('My Project');
+        $hotp->setLabel('alice@foo.bar');
+
+        $uri = $hotp->getProvisioningUri();
+
+        static::assertStringContainsString('otpauth://hotp/My%20Project%3Aalice%40foo.bar?', $uri);
+        static::assertStringContainsString('issuer=My%20Project', $uri);
     }
 
     #[Test]

--- a/tests/TOTPTest.php
+++ b/tests/TOTPTest.php
@@ -26,9 +26,46 @@ final class TOTPTest extends TestCase
     public function labelNotDefined(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The label is not set.');
+        $this->expectExceptionMessage('The label is not set. Either label or issuer must be set.');
         $otp = TOTP::generate(new InternalClock());
         $otp->getProvisioningUri();
+    }
+
+    #[Test]
+    public function provisioningUriWithIssuerOnly(): void
+    {
+        $otp = TOTP::generate(new InternalClock());
+        $otp->setIssuer('My Issuer');
+
+        $uri = $otp->getProvisioningUri();
+
+        static::assertStringContainsString('otpauth://totp/My%20Issuer?', $uri);
+        static::assertStringContainsString('issuer=My%20Issuer', $uri);
+    }
+
+    #[Test]
+    public function provisioningUriWithLabelOnly(): void
+    {
+        $otp = TOTP::generate(new InternalClock());
+        $otp->setLabel('alice@foo.bar');
+
+        $uri = $otp->getProvisioningUri();
+
+        static::assertStringContainsString('otpauth://totp/alice%40foo.bar?', $uri);
+        static::assertStringNotContainsString('issuer=', $uri);
+    }
+
+    #[Test]
+    public function provisioningUriWithIssuerAndLabel(): void
+    {
+        $otp = TOTP::generate(new InternalClock());
+        $otp->setIssuer('My Project');
+        $otp->setLabel('alice@foo.bar');
+
+        $uri = $otp->getProvisioningUri();
+
+        static::assertStringContainsString('otpauth://totp/My%20Project%3Aalice%40foo.bar?', $uri);
+        static::assertStringContainsString('issuer=My%20Project', $uri);
     }
 
     #[Test]


### PR DESCRIPTION
Target branch: 11.4.x / master

- [x] It is a Bug fix
- [ ] It is a New feature
- [ ] Breaks BC
- [ ] Includes Deprecations

Allows for creation of OTP uri with only issuer or label. Label is no longer required (if issuer is specified).
