### PR TITLE
ci: add tests for PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
           - php-version: '8.2'
           - php-version: '8.3'
           - php-version: '8.4'
+          - php-version: '8.5'
     container:
       image: ghcr.io/spomky-labs/phpqa:${{ matrix.php-version }}
     env:


### PR DESCRIPTION
i am not sure if i should update all 8.4 references to 8.5