### PR TITLE
fix: enforce minimum digest length

### DIFF
--- a/doc/Customize.md
+++ b/doc/Customize.md
@@ -113,19 +113,25 @@ $otp = $otp->withCounter(1000); // The counter is now 1000. We recommend you sta
 ## Digest
 
 By default the digest algorithm is `sha1`.
-You can use any algorithm listed by [`hash_algos()`](http://php.net/manual/en/function.hash-algos.php).
-Note that most applications only support `md5`, `sha1`, `sha256` and `sha512`.
-You must verify that the algorithm you want to use is supported by the application your clients might be using.
+You can use any HMAC algorithm listed by [`hash_hmac_algos()`](http://php.net/manual/en/function.hash-hmac-algos.php)
+**that produces a digest of at least 19 bytes**. Shorter digests (such as `md5`, 16 bytes)
+are rejected: the RFC 4226 dynamic truncation reads up to the 19th byte of the digest, so a
+shorter hash would read past its end and collapse the OTP to a small, secret-independent set
+of values — a real weakness, not a theoretical one.
 
-`SHA-2` algorithms are recommended.
+The spec-compliant, interoperable values are `sha1`, `sha256` and `sha512`. Most authenticator
+applications only support these, so you must verify that the algorithm you want to use is
+supported by the application your clients might be using.
+
+`SHA-2` algorithms (`sha256`, `sha512`) are recommended.
 
 ```php
 <?php
 use OTPHP\TOTP;
 
 $totp = TOTP::generate();
-$totp = $totp->withPeriod(30)           // The period (30 seconds)
-    ->withDigest('ripemd160');  // The digest algorithm
+$totp = $totp->withPeriod(30)       // The period (30 seconds)
+    ->withDigest('sha256');         // The digest algorithm
 ```
 
 ## Digits

--- a/doc/UPGRADE_v11-v12.md
+++ b/doc/UPGRADE_v11-v12.md
@@ -4,6 +4,57 @@ This document provides guidance for upgrading from OTPHP v11.x to v12.0.
 
 ## Breaking Changes
 
+### Digest Algorithm Minimum Length Enforcement (since v11.5)
+
+**Impact:** MEDIUM - Affects only configurations using a digest shorter than 19 bytes (e.g. `md5`)
+
+> This change ships in **v11.5.0**, not v12.0. It is listed here so that anyone bumping from
+> v11.4 to v11.5 (or planning the move to v12) is aware of it.
+
+Since v11.5.0, OTPHP rejects any digest algorithm whose raw output is shorter than **19 bytes**.
+The RFC 4226 dynamic truncation reads four bytes starting at an offset in the range `[0, 15]`,
+i.e. up to the 19th byte of the digest. A shorter hash makes the truncation read past the end
+of the digest, collapsing the generated code to a small, secret-independent set of values — a
+real weakness in the verification path, not a theoretical one. Such algorithms are also outside
+RFC 4226/6238 and are not interoperable with authenticator applications.
+
+Concretely, `md5` (16 bytes) and other short digests (`md4`, `ripemd128`, `tiger128`, …) are no
+longer accepted. The validation now relies on
+[`hash_hmac_algos()`](https://php.net/manual/en/function.hash-hmac-algos.php) instead of
+`hash_algos()`, which also rejects non-HMAC algorithms (`crc32`, `adler32`, …) that previously
+slipped through and crashed later in `hash_hmac()`.
+
+#### What breaks
+
+Both entry points throw on a too-short digest:
+
+```php
+// Direct configuration
+TOTP::generate(new InternalClock())->withDigest('md5'); // InvalidParameterException
+
+// Provisioning URI
+Factory::loadFromProvisioningUri(
+    'otpauth://totp/Foo:alice@foo.bar?algorithm=md5&secret=JDDK4U6G3BJLEZ7Y',
+    new InternalClock()
+); // InvalidProvisioningUriException
+```
+
+#### Migration Path
+
+Use a spec-compliant, interoperable digest. `sha1`, `sha256` and `sha512` are the only values
+defined by RFC 4226/6238 and supported by authenticator apps; `SHA-2` is recommended.
+
+```php
+// Before
+$totp = $totp->withDigest('md5');
+
+// After
+$totp = $totp->withDigest('sha256');
+```
+
+Accounts previously provisioned with `md5` were already insecure and non-interoperable. They
+must be re-enrolled with a supported algorithm.
+
 ### Readonly Classes - Mutable Methods Removed
 
 **Impact:** HIGH - Affects all code using setter methods
@@ -278,6 +329,9 @@ Providing a Clock implementation has several benefits:
 4. **Best Practice:** Following PSR-20 standard promotes better architecture
 
 ## Timeline
+
+### Digest Algorithm Length Enforcement
+- **v11.5.0:** Digests shorter than 19 bytes (e.g. `md5`) and non-HMAC algorithms are rejected
 
 ### PSR-20 Clock Changes
 - **v11.3.0:** Clock parameter introduced as optional

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -18,6 +18,7 @@ use OTPHP\Exception\SecretDecodingException;
 use ParagonIE\ConstantTime\Base32;
 use function sprintf;
 use const STR_PAD_LEFT;
+use function strlen;
 
 /**
  * @readonly
@@ -25,6 +26,19 @@ use const STR_PAD_LEFT;
 abstract class OTP implements OTPInterface
 {
     private const DEFAULT_SECRET_SIZE = 64;
+
+    /**
+     * Minimum digest size, in bytes, required by the RFC 4226 dynamic truncation.
+     *
+     * The truncation reads four bytes starting at an offset taken from the low
+     * nibble of the last digest byte, i.e. an offset in the range [0, 15]. It
+     * therefore reads up to index "offset + 3" = 18 and needs at least 19 bytes.
+     * A shorter digest (e.g. MD5, 16 bytes) makes the truncation read past the
+     * end of the hash, collapsing the output to a small, secret-independent set
+     * of values. Such algorithms are also outside RFC 4226/6238 and are not
+     * interoperable with authenticator apps. See {@see self::generateOTP()}.
+     */
+    private const MINIMUM_DIGEST_SIZE = 19;
 
     /**
      * @var array<non-empty-string, mixed>
@@ -343,8 +357,19 @@ abstract class OTP implements OTPInterface
             'secret' => static fn (string $value): string => strtoupper(trim($value, '=')),
             'algorithm' => static function (string $value): string {
                 $value = strtolower($value);
-                in_array($value, hash_algos(), true) || throw new InvalidParameterException(
+                in_array($value, hash_hmac_algos(), true) || throw new InvalidParameterException(
                     sprintf('The "%s" digest is not supported.', $value),
+                    'algorithm',
+                    $value
+                );
+                $size = strlen(hash($value, '', true));
+                $size >= self::MINIMUM_DIGEST_SIZE || throw new InvalidParameterException(
+                    sprintf(
+                        'The "%s" digest produces a %d-byte hash which is too short for the RFC 4226 dynamic truncation; at least %d bytes are required.',
+                        $value,
+                        $size,
+                        self::MINIMUM_DIGEST_SIZE
+                    ),
                     'algorithm',
                     $value
                 );

--- a/src/OTPInterface.php
+++ b/src/OTPInterface.php
@@ -137,7 +137,7 @@ interface OTPInterface
     public function getDigits(): int;
 
     /**
-     * @return non-empty-string Digest algorithm used to calculate the OTP. Possible values are 'md5', 'sha1', 'sha256' and 'sha512'
+     * @return non-empty-string Digest algorithm used to calculate the OTP. Spec-compliant, interoperable values are 'sha1', 'sha256' and 'sha512'. Any digest shorter than 19 bytes (e.g. 'md5') is rejected as it cannot satisfy the RFC 4226 dynamic truncation.
      */
     public function getDigest(): string;
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -49,6 +49,16 @@ final class FactoryTest extends TestCase
     }
 
     #[Test]
+    public function loadingAProvisioningUriWithAShortDigestAlgorithmIsRejected(): void
+    {
+        $this->expectException(InvalidProvisioningUriException::class);
+        $this->expectExceptionMessage('Not a valid OTP provisioning URI');
+        $otp = 'otpauth://totp/My%20Project%3Aalice%40foo.bar?algorithm=md5&secret=JDDK4U6G3BJLEZ7Y';
+
+        Factory::loadFromProvisioningUri($otp, new InternalClock());
+    }
+
+    #[Test]
     public function tOTPObjectDoesNotHaveRequestedParameter(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/HOTPTest.php
+++ b/tests/HOTPTest.php
@@ -6,6 +6,7 @@ namespace OTPHP\Test;
 
 use InvalidArgumentException;
 use OTPHP\HOTP;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -201,6 +202,37 @@ final class HOTPTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" digest is not supported.');
         $htop->setDigest('foo');
+    }
+
+    #[Test]
+    public function digestTooShortIsRejected(): void
+    {
+        $htop = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The "md5" digest produces a 16-byte hash which is too short for the RFC 4226 dynamic truncation; at least 19 bytes are required.'
+        );
+        $htop->withDigest('md5');
+    }
+
+    #[Test]
+    #[DataProvider('specCompliantDigests')]
+    public function specCompliantDigestsAreAccepted(string $digest): void
+    {
+        $htop = HOTP::createFromSecret('JDDK4U6G3BJLEZ7Y')->withDigest($digest);
+
+        static::assertSame($digest, $htop->getDigest());
+    }
+
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function specCompliantDigests(): iterable
+    {
+        yield ['sha1'];
+        yield ['sha256'];
+        yield ['sha512'];
     }
 
     /**


### PR DESCRIPTION
## What

Reject digest algorithms that cannot satisfy the RFC 4226 dynamic truncation.

The truncation reads four bytes starting at an offset taken from the low nibble of the last digest byte, i.e. an offset in `[0, 15]`, so it reads up to the **19th byte**. A digest shorter than 19 bytes (e.g. `md5`, 16 bytes) makes the truncation read past the end of the hash, collapsing the generated **and verified** OTP to a small, secret-independent set of values.

This is framed as an **enforcement of the spec constraint**, not a nominative blacklist: the length rule generically rejects every too-short digest (`md4`, `ripemd128`, `tiger128`, …), `md5` being one case.

## Changes

- `OTP::getParameterMap()` validates the `algorithm` against `hash_hmac_algos()` (instead of `hash_algos()`), which also rejects non-HMAC algorithms (`crc32`, `adler32`, …) that previously slipped through and crashed later in `hash_hmac()`.
- A minimum digest size of **19 bytes** is enforced, computed dynamically via `strlen(hash($algo, '', true))` — no per-algorithm magic values, robust to future PHP additions.
- Both entry points are covered: the direct setter (`withDigest`/`setDigest`) and the `otpauth://` provisioning URI (`Factory::loadFromProvisioningUri`).
- Docblock of `OTPInterface::getDigest()` and `doc/Customize.md` no longer present `md5` as a supported value.
- Behavioural change documented in `doc/UPGRADE_v11-v12.md` (ships in **v11.5.0**).

## Compatibility

Breaking for accounts configured with a sub-19-byte digest (`md5` & co.) — those were already out of spec and non-interoperable with authenticator apps. They must be re-enrolled with `sha1`, `sha256` or `sha512`.

## Tests / QA

- New tests: short-digest rejection (direct setter + provisioning URI), spec-compliant digests accepted.
- Full suite green: phpunit (160 tests / 440 assertions), phpstan (max), ecs, rector, deptrac (0 violations), lint.