### PR TITLE
Add docstring to InternalClock::now() method

### DIFF
--- a/src/InternalClock.php
+++ b/src/InternalClock.php
@@ -14,6 +14,9 @@ use Psr\Clock\ClockInterface;
  */
 final class InternalClock implements ClockInterface
 {
+    /**
+     * Returns the current time as a DateTimeImmutable object.
+     */
     public function now(): DateTimeImmutable
     {
         return new DateTimeImmutable();


### PR DESCRIPTION
## Problem Background
The public method `now()` in `InternalClock` class implements the `Psr\Clock\ClockInterface` but lacks a docstring. Adding documentation improves code readability and self-documentation, making it easier for developers to understand the method's purpose and behavior.

## Changes Made
- Added a docstring to the `now()` method in `src/InternalClock.php` to describe its functionality: returning the current time as a `DateTimeImmutable` object.

## Verification
- The change is minimal and only adds documentation, so it should not affect functionality.
- Run the existing test suite to ensure no regressions or failures are introduced. The code should pass all tests as before.
- Verify that the docstring style is consistent with the repository's existing conventions.