### PR TITLE
perf: avoid array allocations in OTP hot path

### DIFF
--- a/src/OTP.php
+++ b/src/OTP.php
@@ -192,7 +192,7 @@ abstract class OTP implements OTPInterface
     public function getParameter(string $parameter): mixed
     {
         if ($this->hasParameter($parameter)) {
-            return $this->getParameters()[$parameter];
+            return $this->parameters[$parameter];
         }
 
         throw new ParameterNotFoundException(sprintf('Parameter "%s" does not exist', $parameter), $parameter);
@@ -295,9 +295,10 @@ abstract class OTP implements OTPInterface
 
         $offset = ($hmac[count($hmac) - 1] & 0xF);
         $code = ($hmac[$offset] & 0x7F) << 24 | ($hmac[$offset + 1] & 0xFF) << 16 | ($hmac[$offset + 2] & 0xFF) << 8 | ($hmac[$offset + 3] & 0xFF);
-        $otp = $code % (10 ** $this->getDigits());
+        $digits = $this->getDigits();
+        $otp = $code % (10 ** $digits);
 
-        return str_pad((string) $otp, $this->getDigits(), '0', STR_PAD_LEFT);
+        return str_pad((string) $otp, $digits, '0', STR_PAD_LEFT);
     }
 
     /**


### PR DESCRIPTION
## Summary

Two micro-optimizations on the `generateOTP()` hot path. No behavior change.

- `getParameter()` reads `$this->parameters` directly instead of through `getParameters()`, which copies the array and conditionally appends `issuer` on every call. Hit 3+ times per generation (for `algorithm`, `secret`, `digits`).
- `generateOTP()` hoists `getDigits()` to a local so the modulo and `str_pad` width no longer recompute it.

Combined savings multiply under `TOTP::verify(..., leeway)` (3 generations) and `HOTP::verify(..., window)` (up to N).

## Why it's safe

`getParameters()` adds `issuer` dynamically, but `getParameter('issuer')` already threw — `hasParameter('issuer')` returns false because `issuer` lives in `$this->issuer`, never in `$this->parameters`. Same for `label`. Grep confirms no callers pass `'issuer'`/`'label'` to `getParameter`. RFC 4226 / 6238 vector tests cover the full generation pipeline across SHA1/256/512.

Verified locally: PHPUnit (160 tests, 440 assertions), PHPStan, ECS, Rector, parallel-lint — all clean.