### PR TITLE
perf: simplify counter packing and dynamic truncation in generateOTP

### DIFF
--- a/src/OTP.php
+++ b/src/OTP.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace OTPHP;
 
 use function array_key_exists;
-use function chr;
 use function count;
 use Exception;
 use function in_array;
@@ -287,14 +286,13 @@ abstract class OTP implements OTPInterface
      */
     protected function generateOTP(int $input): string
     {
-        $hash = hash_hmac($this->getDigest(), $this->intToByteString($input), $this->getDecodedSecret(), true);
-        $unpacked = unpack('C*', $hash);
-        $unpacked !== false || throw new InvalidParameterException('Invalid data.', 'hash', $hash);
-        /** @var list<int> $hmac */
-        $hmac = array_values($unpacked);
+        $hash = hash_hmac($this->getDigest(), pack('J', $input), $this->getDecodedSecret(), true);
 
-        $offset = ($hmac[count($hmac) - 1] & 0xF);
-        $code = ($hmac[$offset] & 0x7F) << 24 | ($hmac[$offset + 1] & 0xFF) << 16 | ($hmac[$offset + 2] & 0xFF) << 8 | ($hmac[$offset + 3] & 0xFF);
+        $offset = ord($hash[strlen($hash) - 1]) & 0xF;
+        $code = (ord($hash[$offset]) & 0x7F) << 24
+            | (ord($hash[$offset + 1]) & 0xFF) << 16
+            | (ord($hash[$offset + 2]) & 0xFF) << 8
+            | (ord($hash[$offset + 3]) & 0xFF);
         $otp = $code % (10 ** $this->getDigits());
 
         return str_pad((string) $otp, $this->getDigits(), '0', STR_PAD_LEFT);
@@ -412,17 +410,6 @@ abstract class OTP implements OTPInterface
         $decoded !== '' || throw new SecretDecodingException('The decoded secret must not be empty.');
 
         return $decoded;
-    }
-
-    private function intToByteString(int $int): string
-    {
-        $result = [];
-        while ($int !== 0) {
-            $result[] = chr($int & 0xFF);
-            $int >>= 8;
-        }
-
-        return str_pad(implode('', array_reverse($result)), 8, "\000", STR_PAD_LEFT);
     }
 
     /**

--- a/src/OTP.php
+++ b/src/OTP.php
@@ -10,6 +10,7 @@ use Exception;
 use function in_array;
 use function is_int;
 use function is_string;
+use function ord;
 use OTPHP\Exception\InvalidLabelException;
 use OTPHP\Exception\InvalidParameterException;
 use OTPHP\Exception\ParameterNotFoundException;


### PR DESCRIPTION
## Summary

Two byte-equivalent simplifications inside `OTP::generateOTP()`. No behavior change.

- `intToByteString()` → `pack('J', $input)`. `J` is unsigned 64-bit big-endian — exactly the RFC 4226 counter encoding. Drops a loop, an array, `array_reverse`, `implode`, and `str_pad` per generation. The private helper is removed.
- `unpack('C*', $hash) + array_values` → direct `ord()` reads on the five bytes the truncation actually uses (last byte for offset, then four at that offset). Removes a ~20-entry int array allocation per generation.

## Why it's safe

Verified byte-equivalence locally: `intToByteString` vs `pack('J')` match for `0`, RFC timecodes, values > 2³², and `PHP_INT_MAX`; old vs new truncation match across 3000 hashes spanning SHA1/256/512. The RFC 6238 Appendix B vectors in `TOTPTest::dataVectors` plus the `at(0)` edge case (where the old `while ($int !== 0)` loop never iterated) exercise the full pipeline.

Verified locally: PHPUnit (160 tests, 440 assertions), PHPStan, ECS, Rector, parallel-lint — all clean.